### PR TITLE
Create runtime directory from unit file

### DIFF
--- a/influxdb.service
+++ b/influxdb.service
@@ -7,6 +7,8 @@ Group=influxdb
 Type=simple
 LimitNOFILE=4096
 ExecStart=/usr/bin/influxdb -config=/etc/influxdb.conf
+RuntimeDirectory=/run/influxdb
+RuntimeDirectoryMode=0755
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The existing unit file fails to start for me, complaining of a missing /run/influxdb directory.
